### PR TITLE
test: chain upgrade

### DIFF
--- a/interchaintest/helpers/poa.go
+++ b/interchaintest/helpers/poa.go
@@ -13,3 +13,8 @@ func POASetPower(ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet
 	cmd := TxCommandBuilder(ctx, chain, []string{"tx", "poa", "set-power", valoper, fmt.Sprintf("%d", power)}, user.KeyName(), flags...)
 	return ExecuteTransaction(ctx, chain, cmd)
 }
+
+func POACreateValidator(ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet, jsonPath string, flags ...string) (sdk.TxResponse, error) {
+	cmd := TxCommandBuilder(ctx, chain, []string{"tx", "poa", "create-validator", jsonPath}, user.KeyName(), flags...)
+	return ExecuteTransaction(ctx, chain, cmd)
+}

--- a/interchaintest/poa_group_test.go
+++ b/interchaintest/poa_group_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/dockerutil"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
+	poatypes "github.com/strangelove-ventures/poa"
 	tokenfactorytypes "github.com/strangelove-ventures/tokenfactory/x/tokenfactory/types"
 	"github.com/stretchr/testify/require"
 
@@ -567,6 +568,51 @@ func createTfMetadata(base, denom, display, name, symbol, description string) ba
 				Exponent: 6,
 				Aliases:  []string{denom},
 			},
+		},
+	}
+}
+
+func createValidator(monicker, valAddr string, pubkey *types.Any) poatypes.MsgCreateValidator {
+	return poatypes.MsgCreateValidator{
+		Description: poatypes.Description{
+			Moniker:         monicker,
+			Identity:        "",
+			Website:         "",
+			SecurityContact: "",
+			Details:         "validator",
+		},
+		Commission:        poatypes.NewCommissionRates(sdkmath.LegacyMustNewDecFromStr("0"), sdkmath.LegacyMustNewDecFromStr("0.2"), sdkmath.LegacyMustNewDecFromStr("0.01")),
+		MinSelfDelegation: sdkmath.NewInt(1),
+		Pubkey:            pubkey,
+		ValidatorAddress:  valAddr,
+	}
+}
+
+func createSetPowerProposal(sender, valAddr string, power int64, unsafe bool) poatypes.MsgSetPower {
+	return poatypes.MsgSetPower{
+		Sender:           sender,
+		ValidatorAddress: valAddr,
+		Power:            uint64(power),
+		Unsafe:           unsafe,
+	}
+}
+
+func createRemoveValidatorProposal(sender, valAddr string) poatypes.MsgRemoveValidator {
+	return poatypes.MsgRemoveValidator{
+		Sender:           sender,
+		ValidatorAddress: valAddr,
+	}
+}
+
+func createSetStakingParamsProposal(sender string, unbondingTime time.Duration, maxValidators uint32, maxEntries uint32, historicalEntries uint32, bondDenom string) poatypes.MsgUpdateStakingParams {
+	return poatypes.MsgUpdateStakingParams{
+		Sender: sender,
+		Params: poatypes.StakingParams{
+			UnbondingTime:     unbondingTime,
+			MaxValidators:     maxValidators,
+			MaxEntries:        maxEntries,
+			HistoricalEntries: historicalEntries,
+			BondDenom:         bondDenom,
 		},
 	}
 }

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -37,6 +37,11 @@ var (
 	acc4Addr     = "manifest1g292xgmcclhq4au5p7580m2s3f8tpwjra644jm"
 	acc4Mnemonic = "myself bamboo retire day exile cancel peanut agree come method odor innocent welcome royal engage key surprise practice capable sauce orient young divert mirror"
 
+	// Taken from https://github.com/manifest-network/manifestjs/blob/main/starship/src/test_helper.ts
+	val1Mnemonic = "venture obtain second cricket please sheriff hybrid eyebrow weasel saddle switch abuse artwork clump ivory vault response diary plunge weekend wheat breeze gaze occur"
+	val1Addr     = "manifestvaloper19h4chfdz729096nm5hhakc22puwwezgg7mz99x"
+	val1Pubkey   = "lnfZyOEx8KQVO1Z3jPxn/03BIPx0Nwu6ApxyEBEWtYM="
+
 	vals      = 2
 	fullNodes = 0
 
@@ -74,7 +79,7 @@ var (
 		Bin:            "manifestd",
 		Bech32Prefix:   "manifest",
 		Denom:          Denom,
-		GasPrices:      "0" + Denom,
+		GasPrices:      "1.0" + Denom,
 		GasAdjustment:  1.3,
 		TrustingPeriod: "508h",
 		NoHostMount:    false,
@@ -82,7 +87,7 @@ var (
 		ModifyGenesis:  cosmos.ModifyGenesis(DefaultGenesis),
 	}
 
-	DefaultGenesisAmt = sdkmath.NewInt(10_000_000)
+	DefaultGenesisAmt = sdkmath.NewInt(10_000_000_000_000)
 )
 
 func init() {


### PR DESCRIPTION
Relates #https://github.com/strangelove-ventures/poa/issues/245

This pull request updates the chain upgrade test for the Manifest Ledger to support the new POA validator induction flow and improves test reliability and coverage. The main changes include updating the chain versions, introducing a new validator induction test after upgrade, and refactoring helper functions for validator management.

**Chain upgrade and validator induction improvements:**

* Updated upgrade test to use newer chain and upgrade versions (`v1.0.5` → `v1.0.9`) and changed repository to `ghcr.io/liftedinit/manifest-ledger` for more accurate upgrade scenarios.
* Added a test flow for inducting a new validator after upgrade, including creating a validator, submitting a POA create-validator transaction, and verifying induction using the POA module. [[1]](diffhunk://#diff-0827cb9e4bdf4edd7fea93bf1e57c429463deb19fc9fcaf4e8b1f295d30bc18bL118-R158) [[2]](diffhunk://#diff-0827cb9e4bdf4edd7fea93bf1e57c429463deb19fc9fcaf4e8b1f295d30bc18bR270-R348)
* Added helper functions for creating POA validator management messages: `createValidator`, `createSetPowerProposal`, `createRemoveValidatorProposal`, and `createSetStakingParamsProposal` for improved test readability and reuse.
* Introduced `POACreateValidator` helper to submit POA validator creation transactions, aligning with the new induction flow.

**Test configuration and reliability improvements:**

* Increased default genesis amount and transaction gas prices for test accounts to improve reliability and reduce test flakiness.
* Added test constants for a new validator (`val1Mnemonic`, `val1Addr`, `val1Pubkey`) to support induction scenarios.
* Reduced the number of validators used in upgrade tests for faster execution and easier validator management.
* Added logic to update staking parameters (unbonding time) in tests for more flexible validator management and to highlight a known POA issue with validator unbonding during upgrades.

These changes ensure the upgrade test accurately reflects real-world validator induction scenarios and improve the maintainability and reliability of the test suite.